### PR TITLE
Intent to remove triggerOnce property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ import ViewportObserver from 'viewport-observer';
 </ViewportObserver>
 ```
 
+You can call `dispose()` of ViewportObserver instance to stop observing and dispose `IntersectionObserver` instance.
+
 ## Config
 
 |  Property   | Type       | Default Value |
@@ -43,7 +45,6 @@ import ViewportObserver from 'viewport-observer';
 | [root](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserver-root) | `Node` | `null` |
 | [rootMargin](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin) | [`DOMString`](https://heycam.github.io/webidl/#idl-DOMString) | `0px` |
 | [threshold](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserverinit-threshold)  | `Array<Number>` | `[0]` |
-| triggerOnce | `Boolean` | `false` |
 
 ## Related
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,33 +12,30 @@ const UNKNOWN_PROPS = [
   'rootMargin',
   'threshold',
   'rootMargin',
-  'triggerOnce',
   'children'
 ];
 
 export default class ViewportObserver extends React.Component {
   static propTypes = {
-    tagName     : PropTypes.string,
-    onChange    : PropTypes.func,
-    onEnter     : PropTypes.func,
-    onLeave     : PropTypes.func,
-    root        : PropTypes.node,
-    rootMargin  : PropTypes.string,
-    threshold   : PropTypes.arrayOf(PropTypes.number),
-    triggerOnce : PropTypes.bool,
-    children    : PropTypes.node
+    tagName    : PropTypes.string,
+    onChange   : PropTypes.func,
+    onEnter    : PropTypes.func,
+    onLeave    : PropTypes.func,
+    root       : PropTypes.node,
+    rootMargin : PropTypes.string,
+    threshold  : PropTypes.arrayOf(PropTypes.number),
+    children   : PropTypes.node
   };
 
   static defaultProps = {
-    tagName     : 'div',
-    onChange    : () => {},
-    onEnter     : () => {},
-    onLeave     : () => {},
-    root        : null,
-    rootMargin  : '0px',
-    threshold   : [0],
-    triggerOnce : false,
-    children    : null
+    tagName    : 'div',
+    onChange   : () => {},
+    onEnter    : () => {},
+    onLeave    : () => {},
+    root       : null,
+    rootMargin : '0px',
+    threshold  : [0],
+    children   : null
   };
 
   constructor(props) {
@@ -83,10 +80,6 @@ export default class ViewportObserver extends React.Component {
       }
 
       this.isIntersected = next;
-
-      if (this.props.triggerOnce) {
-        this.dispose();
-      }
     }, {
       root       : this.props.root,
       rootMargin : this.props.rootMargin,

--- a/test/index.js
+++ b/test/index.js
@@ -94,61 +94,6 @@ describe('ViewportObserver', () => {
     }, 600);
   });
 
-  it('should fire only `onChange` once with triggerOnce property', done => {
-    const onEnter = () => {};
-    const onChange = () => {};
-    const onLeave = () => {};
-
-    const spiedOnEnter = sinon.spy(onEnter);
-    const spiedOnChange = sinon.spy(onChange);
-    const spiedOnLeave = sinon.spy(onLeave);
-
-    const props = {
-      onEnter     : spiedOnEnter,
-      onChange    : spiedOnChange,
-      onLeave     : spiedOnLeave,
-      triggerOnce : true
-    };
-
-    const component = ReactDOM.render(<ViewportObserver {...props} />, div);
-    const node = TestUtils.findRenderedDOMComponentWithTag(component, 'div');
-
-    document.body.style.height = '1000px';
-    node.style.marginTop = '10px';
-    node.style.height = '100px';
-
-    setTimeout(() => {
-      window.scrollTo(0, 10);
-    }, 100);
-
-    setTimeout(() => {
-      assert(!spiedOnEnter.called);
-      assert(spiedOnChange.called);
-      assert(!spiedOnLeave.called);
-    }, 200);
-
-    setTimeout(() => {
-      window.scrollTo(0, 110);
-    }, 300);
-
-    setTimeout(() => {
-      assert(!spiedOnEnter.called);
-      assert(spiedOnChange.calledOnce);
-      assert(!spiedOnLeave.called);
-    }, 400);
-
-    setTimeout(() => {
-      window.scrollTo(0, 111);
-    }, 500);
-
-    setTimeout(() => {
-      assert(!spiedOnEnter.called);
-      assert(spiedOnChange.calledOnce);
-      assert(!spiedOnLeave.called);
-      done();
-    }, 600);
-  });
-
   it('should be disposed after unmount', () => {
     const component = ReactDOM.render(<ViewportObserver tagName="span" />, div);
 


### PR DESCRIPTION
`triggerOnce` is confusing to use, a reason for **once for which triggers: `onEnter()`, `onChange()`, `onLeave()`**.

Creating `***Once` properties for each triggers is also a solution, but it will make this-self complicated.