### PR TITLE
Upgrading to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    "env",
     "react"
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babelify": "^8.0.0",
     "browserify": "^14.4.0",


### PR DESCRIPTION
A log the one shown below was displayed.
So, using `babel-preset-env` now!

```
$ npm i
npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
```

<a href="https://babeljs.io/env/" >babel-preset-es2015 -> babel-preset-env · Babel</a>