### PR TITLE
Intent to add `display` property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ You can call `dispose()` of ViewportObserver instance to stop observing and disp
 |  Property   | Type       | Default Value |
 | ----------- | ---------- | ------------- |
 | tagName | `String` | `div` |
+| display | `String` | `''` |
 | onChange | `Function` | `() => {}` |
 | onEnter | `Function` | `() => {}` |
 | onLeave | `Function` | `() => {}` |

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default class ViewportObserver extends React.Component {
 
   static defaultProps = {
     tagName    : 'div',
-    display    : 'block',
+    display    : '',
     onChange   : () => {},
     onEnter    : () => {},
     onLeave    : () => {},
@@ -105,9 +105,11 @@ export default class ViewportObserver extends React.Component {
         props[key] = this.props[key];
       });
 
-    props.style = {
-      display : this.props.display
-    };
+    if (this.props.display !== '') {
+      props.style = {
+        display : this.props.display
+      };
+    }
 
     return React.createElement(this.props.tagName, {
       ...props,

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import * as PropTypes from 'prop-types';
 
 const UNKNOWN_PROPS = [
   'tagName',
+  'display',
   'onChange',
   'onEnter',
   'onLeave',
@@ -18,6 +19,7 @@ const UNKNOWN_PROPS = [
 export default class ViewportObserver extends React.Component {
   static propTypes = {
     tagName    : PropTypes.string,
+    display    : PropTypes.string,
     onChange   : PropTypes.func,
     onEnter    : PropTypes.func,
     onLeave    : PropTypes.func,
@@ -29,6 +31,7 @@ export default class ViewportObserver extends React.Component {
 
   static defaultProps = {
     tagName    : 'div',
+    display    : 'block',
     onChange   : () => {},
     onEnter    : () => {},
     onLeave    : () => {},
@@ -101,6 +104,10 @@ export default class ViewportObserver extends React.Component {
       .forEach(key => {
         props[key] = this.props[key];
       });
+
+    props.style = {
+      display : this.props.display
+    };
 
     return React.createElement(this.props.tagName, {
       ...props,

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,13 @@ describe('ViewportObserver', () => {
     assert.equal(node.className, 'a');
   });
 
+  it('should have expected CSS `display` property', () => {
+    const component = TestUtils.renderIntoDocument(<ViewportObserver display="inline-flex" />);
+    const node = TestUtils.findRenderedDOMComponentWithTag(component, 'div');
+
+    assert.equal(node.style.display, 'inline-flex');
+  });
+
   it('should fire `onEnter` -> `onChange` -> `onLeave`', done => {
     const onEnter = () => {};
     const onChange = () => {};

--- a/test/index.js
+++ b/test/index.js
@@ -19,11 +19,14 @@ describe('ViewportObserver', () => {
     document.body.removeChild(div);
   });
 
-  it('should be rendered as div default', () => {
+  it('should be rendered with default values', () => {
     const component = TestUtils.renderIntoDocument(<ViewportObserver />);
     const node = TestUtils.findRenderedDOMComponentWithTag(component, 'div');
 
     assert.notEqual(node, null);
+
+    assert.equal(node.className, '');
+    assert.equal(node.style.display, '');
   });
 
   it('should be rendered as specified `tagName`', () => {


### PR DESCRIPTION
Now ViewportObserver is `display: block` with `<div>` as default and `tagName` property is not enough for setting VO's CSS `display` property.

Any better idea for this?

- [x] Update `README.md` after discussion