### PR TITLE
Fixed types props

### DIFF
--- a/type/index.d.ts
+++ b/type/index.d.ts
@@ -6,6 +6,7 @@ import * as React from 'react';
 declare namespace ViewportObserver {
   export interface Props {
     tagName?: string;
+    display?: string;
     onChange?: (entry: IntersectionObserverEntry) => void;
     onEnter?: () => void;
     onLeave?: () => void;


### PR DESCRIPTION
It seems that you forgot to modify `type/index.d.ts` when doing this issue (https://github.com/openfresh/viewport-observer/pull/21)

I want to use `display` property in TypeScript.